### PR TITLE
build(cmake): add an ability to opt in only for certain CV-CUDA operators

### DIFF
--- a/src/cvcuda/CMakeLists.txt
+++ b/src/cvcuda/CMakeLists.txt
@@ -16,7 +16,9 @@
 # cvcuda private implementation
 add_subdirectory(priv)
 
-add_library(cvcuda SHARED
+set(CV_CUDA_LIB_FILES Operator.cpp)
+
+set(CV_CUDA_OP_FILES
     OpBoxBlur.cpp
     OpBndBox.cpp
     OpBrightnessContrast.cpp
@@ -24,7 +26,6 @@ add_library(cvcuda SHARED
     OpColorTwist.cpp
     OpCropFlipNormalizeReformat.cpp
     OpNonMaximumSuppression.cpp
-    Operator.cpp
     OpReformat.cpp
     OpResize.cpp
     OpCustomCrop.cpp
@@ -55,6 +56,29 @@ add_library(cvcuda SHARED
     OpAdaptiveThreshold.cpp
     OpRandomResizedCrop.cpp
     OpGaussianNoise.cpp
+)
+
+# filter only one that matches the patern (case insensitive), should be set on the global level
+# usage:
+# set(CV_CUDA_SRC_PATERN medianblur median_blur"
+#
+# will compile only files relevant to themedian blur op "OpMedianBlur.cpp"
+if (NOT "${CV_CUDA_SRC_PATERN}" STREQUAL "")
+    foreach(PATTERN ${CV_CUDA_SRC_PATERN})
+        string(TOLOWER ${PATTERN} PATTERN)
+        foreach(FILENAME ${CV_CUDA_OP_FILES})
+            string(TOLOWER ${FILENAME} FILENAME_LOWERCASE)
+            if (${FILENAME_LOWERCASE} MATCHES ${PATTERN})
+                list(APPEND CV_CUDA_LIB_FILES ${FILENAME})
+            endif()
+        endforeach()
+    endforeach()
+else()
+    list(APPEND CV_CUDA_LIB_FILES ${CV_CUDA_OP_FILES})
+endif()
+
+add_library(cvcuda SHARED
+    ${CV_CUDA_LIB_FILES}
 )
 
 target_link_libraries(cvcuda

--- a/src/cvcuda/priv/CMakeLists.txt
+++ b/src/cvcuda/priv/CMakeLists.txt
@@ -15,7 +15,9 @@
 
 add_subdirectory(legacy)
 
-add_library(cvcuda_priv STATIC
+set(CV_CUDA_PRIV_FILES IOperator.cpp)
+
+set(CV_CUDA_PRIV_OP_FILES
     OpBoxBlur.cpp
     OpBndBox.cpp
     OpBrightnessContrast.cu
@@ -23,7 +25,6 @@ add_library(cvcuda_priv STATIC
     OpColorTwist.cu
     OpCropFlipNormalizeReformat.cu
     OpNonMaximumSuppression.cu
-    IOperator.cpp
     OpReformat.cpp
     OpResize.cpp
     OpCustomCrop.cpp
@@ -54,6 +55,29 @@ add_library(cvcuda_priv STATIC
     OpAdaptiveThreshold.cpp
     OpRandomResizedCrop.cpp
     OpGaussianNoise.cpp
+)
+
+# filter only one that matches the patern (case insensitive), should be set on the global level
+# usage:
+# set(CV_CUDA_SRC_PATERN medianblur median_blur"
+#
+# will compile only files relevant to themedian blur op "OpMedianBlur.cpp"
+if (NOT "${CV_CUDA_SRC_PATERN}" STREQUAL "")
+    foreach(PATTERN ${CV_CUDA_SRC_PATERN})
+        string(TOLOWER ${PATTERN} PATTERN)
+        foreach(FILENAME ${CV_CUDA_PRIV_OP_FILES})
+            string(TOLOWER ${FILENAME} FILENAME_LOWERCASE)
+            if (${FILENAME_LOWERCASE} MATCHES ${PATTERN})
+                list(APPEND CV_CUDA_PRIV_FILES ${FILENAME})
+            endif()
+        endforeach()
+    endforeach()
+else()
+    list(APPEND CV_CUDA_PRIV_FILES ${CV_CUDA_PRIV_OP_FILES})
+endif()
+
+add_library(cvcuda_priv STATIC
+    ${CV_CUDA_PRIV_FILES}
 )
 
 target_link_libraries(cvcuda_priv

--- a/src/cvcuda/priv/legacy/CMakeLists.txt
+++ b/src/cvcuda/priv/legacy/CMakeLists.txt
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(cvcuda_legacy STATIC
+set(CV_CUDA_PRIV_LEGACY_FILES CvCudaLegacyHelpers.cpp)
+
+set(CV_CUDA_PRIV_LEGACY_OP_FILES
     filter_utils.cu
     custom_crop.cu
     reformat.cu
@@ -49,7 +51,6 @@ add_library(cvcuda_legacy STATIC
     flip.cu
     flip_or_copy_var_shape.cu
     composite_var_shape.cu
-    CvCudaLegacyHelpers.cpp
     custom_crop.cu
     reformat.cu
     resize.cu
@@ -73,6 +74,29 @@ add_library(cvcuda_legacy STATIC
     gaussian_noise.cu
     gaussian_noise_var_shape.cu
     gaussian_noise_util.cu
+)
+
+# filter only one that matches the patern (case insensitive), should be set on the global level
+# usage:
+# set(CV_CUDA_SRC_PATERN medianblur median_blur"
+#
+# will compile only files relevant to themedian blur op "median_blur.cu;median_blur_var_shape.cu"
+if (NOT "${CV_CUDA_SRC_PATERN}" STREQUAL "")
+    foreach(PATTERN ${CV_CUDA_SRC_PATERN})
+        string(TOLOWER ${PATTERN} PATTERN)
+        foreach(FILENAME ${CV_CUDA_PRIV_LEGACY_OP_FILES})
+            string(TOLOWER ${FILENAME} FILENAME_LOWERCASE)
+            if (${FILENAME_LOWERCASE} MATCHES ${PATTERN})
+                list(APPEND CV_CUDA_PRIV_LEGACY_FILES ${FILENAME})
+            endif()
+        endforeach()
+    endforeach()
+else()
+    list(APPEND CV_CUDA_PRIV_LEGACY_FILES ${CV_CUDA_PRIV_LEGACY_OP_FILES})
+endif()
+
+add_library(cvcuda_legacy STATIC
+    ${CV_CUDA_PRIV_LEGACY_FILES}
 )
 
 target_link_libraries(cvcuda_legacy


### PR DESCRIPTION
- adds an ability to compile only CV-CUDA files that match the
  given pattern so the user can have binary only with selected
  operators (which also reduces its size)