### PR TITLE
Fix #274: Make StreamStack thread-local to prevent cross-thread interference

### DIFF
--- a/python/mod_cvcuda/nvcv/StreamStack.cpp
+++ b/python/mod_cvcuda/nvcv/StreamStack.cpp
@@ -48,7 +48,7 @@ std::shared_ptr<Stream> StreamStack::top()
 
 StreamStack &StreamStack::Instance()
 {
-    static StreamStack stack;
+    thread_local static StreamStack stack;
     return stack;
 }
 


### PR DESCRIPTION
Fixes #274

The StreamStack singleton was being shared globally across all threads, causing thread interference where one thread could see another thread's active stream. This resulted in crashes when using cvcuda.Stream in multi-threaded applications.

Solution: Changed the static singleton to thread_local static, ensuring each thread has its own StreamStack instance.

## Testing & Verification

**Reproduction Test:**
Created a multi-threaded test with 2 threads, each creating and activating its own `cvcuda.Stream`:
- Thread 1: Creates stream_1, pushes it, expects `Stream.current` to be stream_1
- Thread 2: Creates stream_2, pushes it, expects `Stream.current` to be stream_2

**Before fix (static):**
- Thread 1 incorrectly saw stream_2 (Thread 2's stream) instead of stream_1
- Resulted in `RuntimeError: current stream (2) != expected stream (1)`
- Crash due to cross-thread interference in shared StreamStack

**After fix (thread_local static):**
- Thread 1 correctly sees only stream_1
- Thread 2 correctly sees only stream_2
- Each thread has its own StreamStack instance
- No cross-thread interference

**Validation:**
Additionally validated with a C++ proof-of-concept demonstrating:
- `static` variable: Shared across threads (broken behavior)
- `thread_local static` variable: Separate instance per thread (correct behavior)

The fix aligns with C++ best practices for thread-safe singleton patterns.