### PR TITLE
Add missing cstdint include to CvCudaOSD

### DIFF
--- a/src/cvcuda/priv/legacy/CvCudaOSD.hpp
+++ b/src/cvcuda/priv/legacy/CvCudaOSD.hpp
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Add an explicit <cstdint> include to CvCudaOSD.hpp so fixed-width integer types are declared directly by the header.