### PR TITLE
fix: include SM120 in AArch64 CUDA builds

### DIFF
--- a/cmake/CUDAArchitecturePolicy.cmake
+++ b/cmake/CUDAArchitecturePolicy.cmake
@@ -71,6 +71,7 @@ function(cvcuda_configure_cuda_architecture_policy)
                 if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "12.8")
                     list(APPEND _CVCUDA_CUDA_ARCHITECTURES
                         100-real # Blackwell GB200, GB300
+                        120-real # RTX Pro 6000, RTX 50**
                     )
                 endif()
                 if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "13.0")

--- a/tests/cmake/test_cuda_architecture_policy.py
+++ b/tests/cmake/test_cuda_architecture_policy.py
@@ -133,6 +133,16 @@ class CUDAArchitecturePolicyTests(unittest.TestCase):
         self.assertEqual(result["architectures"], "86-real;87-real;89-real")
         self.assertEqual(result["active"], "OFF")
 
+    def test_cuda13_aarch64_sbsa_defaults_include_sm120(self):
+        result = self.configure(
+            "-DTEST_CUDA_VERSION=13.0",
+            "-DTEST_PROCESSOR=aarch64",
+        )
+        self.assertEqual(
+            result["architectures"],
+            "80-real;86-real;89-real;90-real;100-real;120-real;110-real;121-real;75-real",
+        )
+
     def test_explicit_cache_values_are_exact(self):
         for architectures in (
             "86-real;89-real",

--- a/tests/cmake/test_cuda_architecture_policy.py
+++ b/tests/cmake/test_cuda_architecture_policy.py
@@ -143,6 +143,16 @@ class CUDAArchitecturePolicyTests(unittest.TestCase):
             "80-real;86-real;89-real;90-real;100-real;120-real;110-real;121-real;75-real",
         )
 
+    def test_cuda128_aarch64_sbsa_defaults_include_sm120(self):
+        result = self.configure(
+            "-DTEST_CUDA_VERSION=12.8",
+            "-DTEST_PROCESSOR=aarch64",
+        )
+        self.assertEqual(
+            result["architectures"],
+            "80-real;86-real;89-real;90-real;100-real;120-real;75-real",
+        )
+
     def test_explicit_cache_values_are_exact(self):
         for architectures in (
             "86-real;89-real",


### PR DESCRIPTION
Fix #296 
## Summary

- add native SM120 code generation to CUDA 12.8+ AArch64 SBSA builds
- add regression coverage for CUDA 12.8 and CUDA 13 defaults

## Validation

- CMake architecture policy tests: 14 passed
- pre-commit hooks passed
- full `cvcuda` target built on AArch64 with CUDA 13.0.88
- confirmed SM120 cubins in `libcvcuda.so`